### PR TITLE
SDET-603 testing jira association vs autolink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+added a change
+
 [![Unit Tests](https://github.com/onXmaps/jirafy-changelog/actions/workflows/tests.yml/badge.svg)](https://github.com/onXmaps/jirafy-changelog/actions/workflows/tests.yml)
 # Jirafy Changelog
 This action generates a changelog from two references, where the markdown is formatted for any referenced Jira tickets.


### PR DESCRIPTION
This PR...
...should create an association to SDET 603 from the PR title (but this line won't contain a link)
...should create an association to [SDET-651] from the PR description
...should create a hyperlink (but no association) to SDET-652 from the PR description
...shouldn't create a hyperlink or association to SDET 653 (this line was added in a later edit)
...should create an association to [SDET-654] after the PR description was edited

[SDET-651]: https://onxmaps.atlassian.net/browse/SDET-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SDET-654]: https://onxmaps.atlassian.net/browse/SDET-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ